### PR TITLE
:memo: More Arch + Philosophy

### DIFF
--- a/mkdocs/contributing/philosophy.md
+++ b/mkdocs/contributing/philosophy.md
@@ -1,11 +1,41 @@
 # Design Philosophy
 
-libhal is a simply a set of interfaces with a defined set of us-
+## D.x Multi Targeted
 
-## Philosophy
+The `libhal`, `libhal` device libraries, and `libhal` utility libraries, should
+work on any target device that also has a toolchain that supports the C++ code.
+`libhal` target libraries should be build able for their designated target and
+host machines for unit testing.
 
-1. Simple
-2. Light Weight
-3. Multi target
-4. Builds Fast
-5. Tested & Testable
+## D.x Light Weight
+
+`libhal` should keep its interfaces and utility code light weight, meaning
+such things do not allocate, and if they do only once, do not perform
+long/length copies, unless a copy was the desired operation,
+
+## D.x General
+
+`libhal` interfaces should be general, meaning that they do not include APIs, or
+configuration settings that are uncommon in most targets or specific to a
+particular target.
+
+## D.x Fast Compilation
+
+`libhal` code should build fast and eliminate/replace any unnecessary
+dependencies that cause compile times to be long.
+
+## D.x Tested & Testable
+
+`libhal` code should be as testable and unit tested.
+
+## D.x Simple
+
+`libhal` aims to be as simple as possible and no simpler. Using its interfaces,
+utility functions, and libraries should be straight forward for most programmers
+to understand with added complexity only when it is necessary and no other
+options exist.
+
+## D.x Safe
+
+`libhal` and its style guide aim to use patterns and techniques that help reduce
+safety issues.

--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -13,15 +13,15 @@ libhal exists to make hardware drivers **🚚 portable**, **🦾 flexible**,
 for embedded drivers, allowing those drivers to be used across different
 processors, microcontrollers, systems, and devices.
 
-!!! Info
-    - Header only
-    - C++20
-    - Only depends on [Boost.LEAF](https://boostorg.github.io/leaf/) for error
-      handling
-    - 🙅🏾 no exceptions
-    - 🙅🏾 no heap usage
-    - ✅ Customizable
-    - 📜 Follows C++ Core Guidelines
+The design philosophy of libhal is to be:
+
+- Multi Targeted
+- Light Weight
+- General
+- Simple
+- Safe
+- Tested & Testable
+- Compiled Quickly
 
 ## The Basics
 


### PR DESCRIPTION
Removed the "info" section from index.md because it didn't really make sense after the talk with Klaus Igleberger. It actually makes more sense to add back the warning badges but for "ALLOCATES" & "THROWS" to warn embedded projects that a project could throw an exception or allocate memory from heap.